### PR TITLE
Add missing m_Delegate release in destructor

### DIFF
--- a/DocumentPicker/DocumentPicker.h
+++ b/DocumentPicker/DocumentPicker.h
@@ -9,7 +9,7 @@ class DocumentPicker : public QObject
 
 public:
     explicit DocumentPicker();
-    ~DocumentPicker() {}
+    ~DocumentPicker();
 
 public slots:
     void show(void);

--- a/DocumentPicker/DocumentPicker.mm
+++ b/DocumentPicker/DocumentPicker.mm
@@ -60,3 +60,8 @@ DocumentPicker::DocumentPicker()
     m_Instance = this;
     m_Delegate = [[DocumentPickerDelegate alloc] initWithObject:this];
 }
+
+DocumentPicker::~DocumentPicker()
+{
+    [m_Delegate release];
+}


### PR DESCRIPTION
Done to avoid memory leak when building the code without Automatic Reference Counting (ARC).